### PR TITLE
CLOUDP-202471: add support to track GH Actions telemetry

### DIFF
--- a/HOWTO.md
+++ b/HOWTO.md
@@ -37,7 +37,7 @@ jobs:
     
     steps:
       - name: Setup AtlasCLI
-        uses: mongodb/mongodb-atlas-cli@main
+        uses: mongodb/atlas-github-action@main
       - name: Use AtlasCLI
         shell: bash
         run: atlas --version # Print Atlas CLI Version

--- a/action.yml
+++ b/action.yml
@@ -122,6 +122,7 @@ runs:
 
         tar -C /tmp -xzf /tmp/mongodb-atlas-cli_*_linux_${ARCH}.tar.gz
         sudo mv /tmp/mongodb-atlas-cli_*_linux_${ARCH}/bin/atlas /usr/bin
+        MONGODB_ATLAS_HOSTNAME="actions" /usr/bin/atlas
 
     - name: Create Project
       if: ${{ inputs.create-project-name && inputs.run-setup == 'false' }}


### PR DESCRIPTION
## Description

[CLOUDP-202471](https://jira.mongodb.org/browse/CLOUDP-202471)

Dependent on https://github.com/mongodb/mongodb-atlas-cli/pull/2379 
Adding support for tracking GH Actions usage via userAgent set by the env var `MONGODB_ATLAS_HOSTNAME`

Additional fly-by HOWTO doc fix


## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation (if appropriate)

## Further comments
