### PR TITLE
task: Update codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
-# Maintained by the MongoDB CLI team
-*       @mongodb/mongocli
+# Maintained by the MongoDB Atlas CLI team
+*       @mongodb/apix-2
 
 # Docs maintained by Docs Cloud Team
 /docs/  @mongodb/docs-cloud-team


### PR DESCRIPTION
Codeowners have been initially set based on atlas CLI however that team no longer exists.

 