### PR TITLE
chore: Add automatic jira creation and closure for gh issues

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 # Maintained by the MongoDB Atlas CLI team
-*       @mongodb/apix-2
+*       @mongodb/apix-devtools
 
 # Docs maintained by Docs Cloud Team
 /docs/  @mongodb/docs-cloud-team

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,5 +5,3 @@ updates:
     schedule:
       interval: weekly
       day: monday
-    reviewers:
-      - "mongodb/apix-2"

--- a/.github/workflows/jira-issue.yml
+++ b/.github/workflows/jira-issue.yml
@@ -1,0 +1,95 @@
+
+---
+  # This workflow automatically creates JIRA tickets when GitHub issues are opened
+  # and closes JIRA tickets when GitHub issues are closed.
+  #
+  # Required secrets:
+  # - JIRA_API_TOKEN: Your JIRA API token
+  #
+  name: Create and close JIRA tickets for GitHub issues
+  
+  on:
+    issues:
+      types: [opened, closed]
+  
+  permissions:
+    issues: write
+    contents: read
+  
+  jobs:
+    jira_task:
+      name: Create Jira issue
+      runs-on: ubuntu-latest
+      if: github.event.action == 'opened'
+      steps:
+        - uses: GitHubSecurityLab/actions-permissions/monitor@v1
+          with:
+            config: ${{ vars.PERMISSIONS_CONFIG }}
+        - name: Create JIRA ticket
+          uses: mongodb/apix-action/create-jira@v13
+          id: create
+          with:
+            token: ${{ secrets.JIRA_API_TOKEN }}
+            project-key: CLOUDP
+            summary: "HELP: GitHub Issue n. ${{ github.event.issue.number }}"
+            issuetype: Story
+            description: "This ticket tracks the following GitHub issue: ${{ github.event.issue.html_url }}."
+            components: AtlasCLI
+            assignee: ${{ vars.ASSIGNEE_JIRA_TICKET }}
+            extra-data: |
+              {
+                "fields": {
+                  "fixVersions": [
+                    {
+                      "name": "Not Applicable"
+                    }
+                  ],
+                  "customfield_12751": [
+                    {
+                      "id": "22223"
+                    }
+                  ],
+                  "customfield_10257": {
+                    "id": "11861"
+                  }
+                }
+              }
+        - name: Add comment
+          uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9
+          with:
+            issue-number: ${{ github.event.issue.number }}
+            body: |
+              Thanks for opening this issue. The ticket [${{ steps.create.outputs.issue-key }}](https://jira.mongodb.org/browse/${{ steps.create.outputs.issue-key }}) was created for internal tracking.
+  
+    close_jira_task:
+      name: Close Jira issue
+      runs-on: ubuntu-latest
+      if: github.event.action == 'closed'
+      steps:
+        - uses: GitHubSecurityLab/actions-permissions/monitor@v1
+          with:
+            config: ${{ vars.PERMISSIONS_CONFIG }}
+
+        - name: Find JIRA ticket by GitHub issue number
+          id: find_jira
+          uses: mongodb/apix-action/find-jira@v13
+          with:
+            token: ${{ secrets.JIRA_API_TOKEN }}
+            jql: "project = CLOUDP AND description ~ '${{ github.event.issue.html_url }}'"
+
+        - name: Close JIRA ticket
+          if: steps.find_jira.outputs.found == 'true'
+          uses: mongodb/apix-action/transition-jira@v13
+          id: close_jira_ticket
+          continue-on-error: true
+          with:
+            token: ${{ secrets.JIRA_API_TOKEN }}
+            issue-key: ${{ steps.find_jira.outputs.issue-key }}
+            transition-id: 1381 # Resolved
+        - name: Add closure comment
+          if: steps.close_jira_ticket.outcome == 'success'
+          uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9
+          with:
+            issue-number: ${{ github.event.issue.number }}
+            body: |
+              The corresponding JIRA ticket has been automatically closed.

--- a/.github/workflows/jira-issue.yml
+++ b/.github/workflows/jira-issue.yml
@@ -1,7 +1,8 @@
 
 ---
-  # This workflow automatically creates JIRA tickets when GitHub issues are opened
-  # and closes JIRA tickets when GitHub issues are closed.
+  # This workflow automatically creates JIRA tickets when GitHub issues are opened,
+  # closes JIRA tickets when GitHub issues are closed, and reopens JIRA tickets
+  # when GitHub issues are reopened.
   #
   # Required secrets:
   # - JIRA_API_TOKEN: Your JIRA API token
@@ -10,14 +11,14 @@
   
   on:
     issues:
-      types: [opened, closed]
+      types: [opened, closed, reopened]
   
   permissions:
     issues: write
     contents: read
   
   jobs:
-    jira_task:
+    open_jira_task:
       name: Create Jira issue
       runs-on: ubuntu-latest
       if: github.event.action == 'opened'
@@ -93,3 +94,36 @@
             issue-number: ${{ github.event.issue.number }}
             body: |
               The corresponding JIRA ticket has been automatically closed.
+
+    reopen_jira_task:
+      name: Reopen Jira issue
+      runs-on: ubuntu-latest
+      if: github.event.action == 'reopened'
+      steps:
+        - uses: GitHubSecurityLab/actions-permissions/monitor@v1
+          with:
+            config: ${{ vars.PERMISSIONS_CONFIG }}
+
+        - name: Find JIRA ticket by GitHub issue number
+          id: find_jira
+          uses: mongodb/apix-action/find-jira@v13
+          with:
+            token: ${{ secrets.JIRA_API_TOKEN }}
+            jql: "project = CLOUDP AND description ~ '${{ github.event.issue.html_url }}'"
+
+        - name: Reopen JIRA ticket
+          if: steps.find_jira.outputs.found == 'true'
+          uses: mongodb/apix-action/transition-jira@v13
+          id: reopen_jira_ticket
+          continue-on-error: true
+          with:
+            token: ${{ secrets.JIRA_API_TOKEN }}
+            issue-key: ${{ steps.find_jira.outputs.issue-key }}
+            transition-id: 1351  # Reopened
+        - name: Add reopen comment
+          if: steps.reopen_jira_ticket.outcome == 'success'
+          uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9
+          with:
+            issue-number: ${{ github.event.issue.number }}
+            body: |
+              The corresponding JIRA ticket has been automatically reopened for internal tracking.


### PR DESCRIPTION
## Description

Adds workflow triggered by Github issue opening or closing to create and close a JIRA ticket for internal tracking.

* Uses[ issues.yml ](https://github.com/mongodb/mongodb-atlas-cli/blob/master/.github/workflows/issues.yml)`Create JIRA ticket for new issues` from atlasCLI
* Uses [jira-issue.yml](https://github.com/mongodb-js/mongodb-mcp-server/blob/main/.github/workflows/jira-issue.yml#L80) `Close Jira issue` from MCP (with transition id adjusted for CLOUDP project)
* Added `secret.JIRA_API_TOKEN` and `vars.ASSIGNEE_JIRA_TICKET` to repo


## Drive-by:
* Updated CODEOWNER team `apix-2` -> `apix-devtools`
  * That is the only team connected to this repo
* Removed `reviewers` from `dependabot.yml`
  * This config option has been deprecated in favour of CODEOWNER files: https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/
