### PR TITLE
CLOUDP-441133: fix service account teardown failing with 401

### DIFF
--- a/build/generate-service-account.sh
+++ b/build/generate-service-account.sh
@@ -27,12 +27,13 @@ if [ -z "$MONGODB_ATLAS_ORG_ID" ]; then
   exit 1
 fi
 if [ -z "$MONGODB_ATLAS_OPS_MANAGER_URL" ]; then
-  echo "MONGODB_ATLAS_ORG_ID env var is not set"
+  echo "MONGODB_ATLAS_OPS_MANAGER_URL env var is not set"
   exit 1
 fi
 
-output=$(
-    curl --user "${MONGODB_ATLAS_PUBLIC_API_KEY}:${MONGODB_ATLAS_PRIVATE_API_KEY}" \
+if ! output=$(
+    curl --silent --show-error --fail-with-body \
+    --user "${MONGODB_ATLAS_PUBLIC_API_KEY}:${MONGODB_ATLAS_PRIVATE_API_KEY}" \
     --digest \
     --header "Accept: application/vnd.atlas.2025-03-12+json" \
     --header "Content-Type: application/json" \
@@ -45,10 +46,17 @@ output=$(
     ],
     "secretExpiresAfterHours": 8
     }'
-)
+); then
+  echo "Failed to create service account. Response:"
+  echo "$output"
+  exit 1
+fi
 
 client_id=$(echo "$output" | jq -r '.clientId')
 client_secret=$(echo "$output" | jq -r '.secrets[0].secret')
+if [ -n "$client_secret" ] && [ "$client_secret" != "null" ]; then
+  echo "::add-mask::$client_secret"
+fi
 
 if [ -z "$client_id" ] || [ "$client_id" = "null" ] || [ -z "$client_secret" ] || [ "$client_secret" = "null" ]; then
   echo "Failed to create service account. Response:"

--- a/build/terminate-service-account.sh
+++ b/build/terminate-service-account.sh
@@ -26,24 +26,26 @@ if [ -z "$MONGODB_ATLAS_ORG_ID" ]; then
   echo "MONGODB_ATLAS_ORG_ID env var is not set"
   exit 1
 fi
+if [ -z "$MONGODB_ATLAS_OPS_MANAGER_URL" ]; then
+  echo "MONGODB_ATLAS_OPS_MANAGER_URL env var is not set"
+  exit 1
+fi
 if [ -z "$CLIENT_ID" ]; then
   echo "CLIENT_ID env var is not set"
   exit 1
 fi
 
-output=$(
-    curl --user "${MONGODB_ATLAS_PUBLIC_API_KEY}:${MONGODB_ATLAS_PRIVATE_API_KEY}" \
+if ! output=$(
+    curl --silent --show-error --fail-with-body \
+    --user "${MONGODB_ATLAS_PUBLIC_API_KEY}:${MONGODB_ATLAS_PRIVATE_API_KEY}" \
     --digest \
     --header "Accept: application/vnd.atlas.2025-03-12+json" \
     --header "Content-Type: application/json" \
-    -X DELETE "https://cloud.mongodb.com/api/atlas/v2/orgs/${MONGODB_ATLAS_ORG_ID}/serviceAccounts/${CLIENT_ID}"
-)
-error_code=$(echo "$output" | jq -r '.error')
-
-if [ "$error_code" -ge 300 ]; then
+    -X DELETE "${MONGODB_ATLAS_OPS_MANAGER_URL}api/atlas/v2/orgs/${MONGODB_ATLAS_ORG_ID}/serviceAccounts/${CLIENT_ID}"
+); then
   echo "Failed to delete service account with Client ID $CLIENT_ID. Response:"
   echo "$output"
   exit 1
-else
-  echo "Service account with Client ID $CLIENT_ID has been deleted successfully."
 fi
+
+echo "Service account with Client ID $CLIENT_ID has been deleted successfully."


### PR DESCRIPTION
The `Setup a Service Account and create a project` job fails **100% of the time** at its final `Delete the Service Account` step, blocking every unrelated PR in this repo (currently #34 and #35). It is not flaky — confirmed across 4 rerun attempts on #34 and again on #35.

`build/generate-service-account.sh` creates the service account against `${MONGODB_ATLAS_OPS_MANAGER_URL}` (`https://cloud-dev.mongodb.com/`, from `vars.CLOUD_DEV_URL`), but `build/terminate-service-account.sh` hardcoded `https://cloud.mongodb.com/`. So the account is created in cloud-dev and the delete is attempted against production, where the configured API keys have no rights:

```
MONGODB_ATLAS_OPS_MANAGER_URL: https://cloud-dev.mongodb.com/
Failed to delete service account with Client ID mdb_sa_id_6a96f1cdfef2f1eb6d9fce78. Response:
{
  "error" : 401,
  "reason" : "Unauthorized",
  "detail" : "You are not authorized for this resource."
}
```

